### PR TITLE
Multiple notifications may be waiting

### DIFF
--- a/lib/Pg/Notify.pm
+++ b/lib/Pg/Notify.pm
@@ -125,7 +125,9 @@ class Pg::Notify {
                 loop {
                     #last if $!run-promise.status ~~ Kept;
                     $!db.pg-consume-input;
-                    if $!db.pg-notifies -> $not {
+
+                    # Retrieve all pending notifications.
+                    while $!db.pg-notifies -> $not {
                         if $not.relname eq $!channel {
                             $supplier.emit: $not;
                         }


### PR DESCRIPTION
Clear the entire buffer before calling libpq PQConsumeInput which may overwrite the buffer.