### PR TITLE
Quit supply on DB error

### DIFF
--- a/lib/Pg/Notify.pm
+++ b/lib/Pg/Notify.pm
@@ -134,6 +134,14 @@ class Pg::Notify {
                     }
 					self.poll-once;
                 }
+
+                # Exceptions inside this block typically indicate some type
+                # of communications issue with the database.
+                CATCH {
+                    default {
+                        $supplier.quit($_);
+                    }
+                }
             }
             $supplier;
         }


### PR DESCRIPTION
Connectivity errors may interrupt a long-lived database connection. Throw those upstream.

This depends on DBIish changes to throw an error on PQconsumeInput failures:
https://github.com/perl6/DBIish/pull/153

Not sure how to test automatically. I manually called pg_terminate_backend(pid) via SQL on a script with a very short react block.

Previously the thread would silently continue listening for traffic on the dead connection.