### PR TITLE
Use @list (cont) $relname

### DIFF
--- a/lib/Pg/Notify.pm
+++ b/lib/Pg/Notify.pm
@@ -128,7 +128,7 @@ class Pg::Notify {
 
                     # Retrieve all pending notifications.
                     while $!db.pg-notifies -> $not {
-                        if @!channel.contains($not.relname) {
+                        if @!channel (cont) $not.relname {
                             $supplier.emit: $not;
                         }
                     }


### PR DESCRIPTION
Raku 2020.01 throws this warning:
  Calling '.contains' on a Array[Str], did you mean 'needle (elem) list'?
    in block  at /opt/rakudo-pkg/share/perl6/site/sources/026AC1E2126403844B8D48B291FE7B939953BBCA (Pg::Notify) line 131

It seems that .contains is a trap, so use the recommended (cont) operator.
  https://docs.perl6.org/language/traps#Lists_become_strings,_so_beware_.contains()